### PR TITLE
Travis: Run on latest version and use containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ language: node_js
 node_js:
   - 0.10
   - 0.12
-  - iojs
+  - 4.1
+  - stable
+sudo: false


### PR DESCRIPTION
> The new containers have 2 dedicated cores and 4GB of memory, vs 1.5 cores and 3GB on our legacy infrastructure. CPU resources are now guaranteed, which means less impact from ‘noisy neighbors’ on the same host machine and more consistent build times throughout the day. (http://docs.travis-ci.com/user/migrating-from-legacy/#More-available-resources)

---

Opened this PR to check that everything is still working.