### PR TITLE
add node-html-parser in wrapper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -132,6 +132,12 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+      "optional": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -195,6 +201,70 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "optional": true
+    },
+    "css-select": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-3.1.2.tgz",
+      "integrity": "sha512-qmss1EihSuBNWNNhHjxzxSfJoFBM/lERB/Q4EnsJQQC62R2evJDW481091oAdOr9uh46/0n4nrg0It5cAnj1RA==",
+      "optional": true,
+      "requires": {
+        "boolbase": "^1.0.0",
+        "css-what": "^4.0.0",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.4.3",
+        "nth-check": "^2.0.0"
+      },
+      "dependencies": {
+        "dom-serializer": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.2.0.tgz",
+          "integrity": "sha512-n6kZFH/KlCrqs/1GHMOd5i2fd/beQHuehKdWvNNffbGHTr/almdhuVvTVFb3V7fglz+nC50fFusu3lY33h12pA==",
+          "optional": true,
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.0.0",
+            "entities": "^2.0.0"
+          }
+        },
+        "domelementtype": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
+          "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
+          "optional": true
+        },
+        "domhandler": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
+          "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
+          "optional": true,
+          "requires": {
+            "domelementtype": "^2.1.0"
+          }
+        },
+        "domutils": {
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.4.tgz",
+          "integrity": "sha512-jBC0vOsECI4OMdD0GC9mGn7NXPLb+Qt6KW1YDQzeQYRUFKmNG8lh7mO5HiELfr+lLQE7loDVI4QcAxV80HS+RA==",
+          "optional": true,
+          "requires": {
+            "dom-serializer": "^1.0.1",
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.0.0"
+          }
+        },
+        "entities": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+          "optional": true
+        }
+      }
+    },
+    "css-what": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-4.0.0.tgz",
+      "integrity": "sha512-teijzG7kwYfNVsUh2H/YN62xW3KK9YhXEgSlbxMlcyjPNvdKJqFx5lrwlJgoFP1ZHlB89iGDlo/JyshKeRhv5A==",
       "optional": true
     },
     "cssom": {
@@ -443,6 +513,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "optional": true
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "optional": true
     },
     "high5": {
@@ -761,6 +837,16 @@
       "integrity": "sha1-vI8IELpB0P19MsOzBQIDTuw6XN8=",
       "optional": true
     },
+    "node-html-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-3.0.1.tgz",
+      "integrity": "sha512-GoBhXdlfEGW24j7acmM1dJLrjlcu2PtFyzeD2Ln65YJD64U2e4e3xUBjx2GW+tLlIiQDL4RfLVw1sdBqRc314A==",
+      "optional": true,
+      "requires": {
+        "css-select": "^3.1.2",
+        "he": "1.2.0"
+      }
+    },
     "node-pre-gyp": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz",
@@ -815,6 +901,15 @@
         "console-control-strings": "~1.1.0",
         "gauge": "~2.7.3",
         "set-blocking": "~2.0.0"
+      }
+    },
+    "nth-check": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
+      "integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
+      "optional": true,
+      "requires": {
+        "boolbase": "^1.0.0"
       }
     },
     "number-is-nan": {

--- a/package.json
+++ b/package.json
@@ -23,18 +23,19 @@
     "progress": "^2.0.3"
   },
   "optionalDependencies": {
-    "html5parser": "^1.1.0",
     "gumbo-parser": "^0.3.0",
+    "high5": "^1.0.0",
     "html-parser": "^0.11.0",
+    "html5": "^1.0.5",
+    "html5parser": "^1.1.0",
     "htmlparser": "^1.7.7",
     "htmlparser2": "^3.10.1",
-    "high5": "^1.0.0",
     "hubbub": "^0.6.2",
     "libxmljs": "^0.19.5",
-    "sax": "^1.2.4",
-    "html5": "^1.0.5",
+    "neutron-html5parser": "^0.2.0",
+    "node-html-parser": "^3.0.1",
     "parse5": "^5.1.0",
-    "neutron-html5parser": "^0.2.0"
+    "sax": "^1.2.4"
   },
   "license": "MIT",
   "engines": {

--- a/wrapper/node-html-parser.js
+++ b/wrapper/node-html-parser.js
@@ -1,0 +1,6 @@
+const { parse } = require("node-html-parser");
+
+module.exports = function (html, callback) {
+    parse(html);
+    callback(null);
+};


### PR DESCRIPTION
When I was looking for a fast html parser for a project, I came across [node-html-parser](https://www.npmjs.com/package/node-html-parser) that claims it is a fast one. I don't know if it's true; however when I tried benchmarking, it gives:
```
[==================================================] 258 / 258

gumbo-parser       : 19.6221 ms/file ± 10.5076
high5 failed (exit code 1)
[==================================================] 258 / 258

html-parser        : 20.3297 ms/file ± 15.9871
[==================================================] 258 / 258

html5              : 112.120 ms/file ± 150.263
[==================================================] 258 / 258

html5parser        : 2.49329 ms/file ± 2.41990
[==================================================] 258 / 258

htmlparser         : 17.5675 ms/file ± 121.541
[==================================================] 258 / 258

htmlparser2-dom    : 2.75237 ms/file ± 4.13799
[==================================================] 258 / 258

htmlparser2        : 2.06259 ms/file ± 3.57613
hubbub failed (exit code 1)
[==================================================] 258 / 258

libxmljs           : 3.12159 ms/file ± 2.48122
[==================================================] 258 / 258

neutron-html5parser: 2.15431 ms/file ± 1.25543
[==================================================] 258 / 258

node-html-parser   : 1.06224 ms/file ± 0.738487
[==================================================] 258 / 258

parse5             : 7.53132 ms/file ± 4.87578
[==================================================] 258 / 258

sax                : 7.82790 ms/file ± 9.33634
```
**NOTE:** I tried `npm i --save-optional node-html-parser` in order to install the module.