### PR TITLE
Add @arijs/stream-xml-parser in wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "progress": "^2.0.3"
   },
   "optionalDependencies": {
+    "@arijs/stream-xml-parser": "^0.2.8",
     "@y21/tljs": "^0.3.1",
     "html-dom-parser": "^1.1.0",
     "html-parser": "^0.11.0",

--- a/wrapper/arijs-stream.js
+++ b/wrapper/arijs-stream.js
@@ -1,0 +1,10 @@
+
+var Parser = require("@arijs/stream-xml-parser").XMLParser;
+
+module.exports = function (html, callback) {
+	var parser = new Parser(nop);
+	parser.end(html);
+	callback();
+};
+
+function nop() {}

--- a/wrapper/arijs-tree.js
+++ b/wrapper/arijs-tree.js
@@ -1,0 +1,11 @@
+
+var AriJS = require("@arijs/stream-xml-parser");
+
+module.exports = function (html, callback) {
+	var builder = new AriJS.TreeBuilder({
+		element: AriJS.elementDefault(),
+	});
+	var parser = new AriJS.XMLParser(builder.parserEvent.bind(builder));
+	parser.end(html);
+	callback();
+};


### PR DESCRIPTION
There are two modes:

- `arijs-stream.js` is a tokenizer, it doesn't build a tree.
- `arijs-tree.js` uses the tokenizer to build a tree.